### PR TITLE
implement Array.Extra.memeber function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # Ignore build or dist files
 elm-stuff
 node_modules
+index.html
+
+# Ignore Generated files
+/tests/VerifyExamples/

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -117,7 +117,7 @@ suite =
             [ ( "with foldr", arrayMemberFoldr )
             , ( "with foldl", arrayMemberFoldl )
             , ( "recursive", arrayMemberRec )
-            , ( "with List.meber", listMember )
+            , ( "with List.member", listMember )
             ]
         ]
 

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -108,6 +108,17 @@ suite =
             [ ( "with Array.foldr", intersperseWithArrayFoldr )
             , ( "with List.intersperse", intersperseWithList )
             ]
+        , let
+            array =
+                Array.fromList <| List.range 0 100
+          in
+          rank "member implementation"
+            (\f -> f 50 array)
+            [ ( "with foldr", arrayMemberFoldr )
+            , ( "with foldl", arrayMemberFoldl )
+            , ( "recursive", arrayMemberRec )
+            , ( "with List.meber", listMember )
+            ]
         ]
 
 

--- a/benchmarks/src/Candidates.elm
+++ b/benchmarks/src/Candidates.elm
@@ -1,4 +1,4 @@
-module Candidates exposing (allRecursive, allWithFold, allWithListAll, anyRecursive, anyWithFold, anyWithListAny, filterMapWithListFilterMap, filterMapWithPush, indexedMapToListWithArrayIndexedMap, indexedMapToListWithFoldr, indexedMapToListWithListIndexedMap, indexedMapToListWithToIndexedList, intersperseWithArrayFoldr, intersperseWithList, map2WithListIndexedMap, map2WithListMap2, mapToListWithFoldr, mapToListWithListMap, reverseWithFoldl, reverseWithFoldlToList, reverseWithListReverse, unzipWithFoldlToArrays, unzipWithListUnzip, unzipWithMaps)
+module Candidates exposing (allRecursive, allWithFold, allWithListAll, anyRecursive, anyWithFold, anyWithListAny, arrayMemberFoldl, arrayMemberFoldr, arrayMemberRec, filterMapWithListFilterMap, filterMapWithPush, indexedMapToListWithArrayIndexedMap, indexedMapToListWithFoldr, indexedMapToListWithListIndexedMap, indexedMapToListWithToIndexedList, intersperseWithArrayFoldr, intersperseWithList, map2WithListIndexedMap, map2WithListMap2, mapToListWithFoldr, mapToListWithListMap, reverseWithFoldl, reverseWithFoldlToList, reverseWithListReverse, unzipWithFoldlToArrays, unzipWithListUnzip, unzipWithMaps, listMember)
 
 import Array exposing (Array)
 import Array.Extra as Array
@@ -210,3 +210,37 @@ intersperseWithList separator array =
         |> Array.toList
         |> List.intersperse separator
         |> Array.fromList
+
+
+arrayMemberFoldr : a -> Array a -> Bool
+arrayMemberFoldr item array =
+    Array.foldr (\i res -> item == i || res) False array
+
+
+arrayMemberFoldl : a -> Array a -> Bool
+arrayMemberFoldl item array =
+    Array.foldl (\i res -> item == i || res) False array
+
+
+arrayMemberRec : a -> Array a -> Bool
+arrayMemberRec item array =
+    arrayMemberRecHelp 0 item array
+
+
+arrayMemberRecHelp : Int -> a -> Array a -> Bool
+arrayMemberRecHelp n item array =
+    case Array.get n array of
+        Just i ->
+            if i == item then
+                True
+
+            else
+                arrayMemberRecHelp (n + 1) item array
+
+        Nothing ->
+            False
+
+
+listMember : a -> Array a -> Bool
+listMember item array =
+    List.member item (Array.toList array)

--- a/src/Array/Extra.elm
+++ b/src/Array/Extra.elm
@@ -1,5 +1,5 @@
 module Array.Extra exposing
-    ( all, any
+    ( all, any, member
     , reverse, update
     , pop, removeAt, removeWhen
     , insertAt, intersperse
@@ -14,7 +14,7 @@ module Array.Extra exposing
 
 # scan
 
-@docs all, any
+@docs all, any, member
 
 
 # alter
@@ -754,3 +754,20 @@ interweave toInterweave =
         )
             ++ untilArrayEnd.toInterweave
             |> Array.fromList
+
+
+{-| Figure out whether an array contains a value
+
+    import Array exposing (fromList)
+
+    fromList [ "Leonardo", "Michelangelo", "Donatello", "Raphael" ]
+        |> member "Donatello"
+    --> True
+
+    fromList [ "Leonardo", "Michelangelo" ]
+        |> member "Raphael"
+    --> False
+-}
+member : a -> Array a -> Bool
+member item array =
+    Array.foldr (\i res -> item == i || res) False array

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -425,6 +425,31 @@ suite =
                             )
                 )
             ]
+        , describe "member"
+            [ Test.fuzz
+                (Fuzz.constant
+                    (\before after ->
+                        { before = before, after = after }
+                    )
+                    |> Fuzz.andMap (Fuzz.array Fuzz.int)
+                    |> Fuzz.andMap (Fuzz.array Fuzz.int)
+                )
+                "exists"
+                (\{ before, after } ->
+                    Array.append
+                        (before |> Array.push 123456)
+                        after
+                        |> member 123456
+                        |> Expect.equal True
+                )
+            , Test.fuzz
+                (Fuzz.array Fuzz.int)
+                "doesn't exists"
+                (Array.filter (\element -> element /= 123456)
+                    >> member 123456
+                    >> Expect.equal False
+                )
+            ]
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -444,7 +444,7 @@ suite =
                 )
             , Test.fuzz
                 (Fuzz.array Fuzz.int)
-                "doesn't exists"
+                "doesn't exist"
                 (Array.filter (\element -> element /= 123456)
                     >> member 123456
                     >> Expect.equal False


### PR DESCRIPTION
Also adds benchmarks for candidate implementations:

* converting to List seems to be fastest for long Arrays
* folding seems to be fastest in most common case
* manual recursion with bailout is slower then rest


This is benchmark result from one of my runs in FireFox:

![image](https://user-images.githubusercontent.com/2130305/188581281-ded6223f-287d-4401-ba99-56b8d06595d6.png)

It almost seems we could just convert to List to do this but it feels wrong.